### PR TITLE
GuidHelper: Swap bytes regardless of the endianness

### DIFF
--- a/Src/UUIDNext/Generator/GuidHelper.cs
+++ b/Src/UUIDNext/Generator/GuidHelper.cs
@@ -6,7 +6,7 @@ namespace UUIDNext.Generator
     {
         public static Guid FromBigEndianBytes(Span<byte> bytes)
         {
-            SwitchByteOrderIfNeeded(bytes);
+            SwitchByteOrder(bytes);
             return new Guid(bytes);
         }
 
@@ -17,18 +17,12 @@ namespace UUIDNext.Generator
                 return false;
             }
 
-            SwitchByteOrderIfNeeded(bytes);
+            SwitchByteOrder(bytes);
             return true;
         }
 
-        private static void SwitchByteOrderIfNeeded(Span<byte> bigEndianBytes)
+        private static void SwitchByteOrder(Span<byte> bigEndianBytes)
         {
-            if (!BitConverter.IsLittleEndian)
-            {
-                // On Big Endian architecture everything is in network byte order so we don't need to switch
-                return;
-            }
-
             Permut(bigEndianBytes, 0, 3);
             Permut(bigEndianBytes, 1, 2);
 


### PR DESCRIPTION
Current implementation makes an incorrect assumption that the `Guid(ReadOnlySpan<byte>)` constructor and `Guid.TryWriteBytes(Span<byte>)` produce different results on big-endian and little-endian systems.

However, they always accept/return mixed-endian bytes. See the implementation:
https://github.com/dotnet/runtime/blob/9129083c2fc6ef32479168f0555875b54aee4dfb/src/libraries/System.Private.CoreLib/src/System/Guid.cs#L56-L73

https://github.com/dotnet/runtime/blob/9129083c2fc6ef32479168f0555875b54aee4dfb/src/libraries/System.Private.CoreLib/src/System/Guid.cs#L838-L858