### PR TITLE
Added support for netstandard 2.0

### DIFF
--- a/Src/UUIDNext.Test/DatabaseSupport/SQLiteUuidTest.cs
+++ b/Src/UUIDNext.Test/DatabaseSupport/SQLiteUuidTest.cs
@@ -11,6 +11,11 @@ namespace UUIDNext.Test.DatabaseSupport
     {
         const string tableName = "uuidTestTable";
 
+        public SQLiteUuidTest()
+        {
+            SQLitePCL.Batteries.Init();
+        }
+
         [Fact]
         public void TestSQLiteWithString()
         {

--- a/Src/UUIDNext.Test/Generator/UuidV7GeneratorTest.cs
+++ b/Src/UUIDNext.Test/Generator/UuidV7GeneratorTest.cs
@@ -81,7 +81,7 @@ namespace UUIDNext.Test.Generator
         public void TestSequence()
         {
             UuidV7Generator generator = new();
-            var date = DateTime.UnixEpoch.AddMilliseconds(1789);
+            var date = DateTimeOffset.FromUnixTimeMilliseconds(0).AddMilliseconds(1789).UtcDateTime;
 
             var guido = generator.New(date);
             var (timestampMsO, sequenceO) = UuidDecoder.DecodeUuidV7(guido);

--- a/Src/UUIDNext.Test/UUIDNext.Test.csproj
+++ b/Src/UUIDNext.Test/UUIDNext.Test.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/UUIDNext.Test/UUIDNext.Test.csproj
+++ b/Src/UUIDNext.Test/UUIDNext.Test.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472;net48</TargetFrameworks>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
 

--- a/Src/UUIDNext.Test/UUIDNext.Test.csproj
+++ b/Src/UUIDNext.Test/UUIDNext.Test.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.1" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net8.0'" Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.8"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NFluent" Version="3.0.3" />
     <PackageReference Include="xunit" Version="2.6.6" />

--- a/Src/UUIDNext/Generator/UuidNameGeneratorBase.cs
+++ b/Src/UUIDNext/Generator/UuidNameGeneratorBase.cs
@@ -13,13 +13,9 @@ namespace UUIDNext.Generator
         {
             //Convert the name to a canonical sequence of octets (as defined by the standards or conventions of its name space);
             var utf8NameByteCount = Encoding.UTF8.GetByteCount(name.Normalize(NormalizationForm.FormC));
-#if NETSTANDARD2_0
+#if NET472_OR_GREATER
             byte[] utf8NameBytes = new byte[utf8NameByteCount];
             Encoding.UTF8.GetBytes(name, 0, name.Length, utf8NameBytes, 0);
-#else
-            Span<byte> utf8NameBytes = (utf8NameByteCount > 256) ? new byte[utf8NameByteCount] : stackalloc byte[utf8NameByteCount];
-            Encoding.UTF8.GetBytes(name, utf8NameBytes);
-#endif
 
             //put the name space ID in network byte order.
             Span<byte> namespaceBytes = stackalloc byte[16];
@@ -27,23 +23,28 @@ namespace UUIDNext.Generator
 
             //Compute the hash of the name space ID concatenated with the name.
             int bytesToHashCount = namespaceBytes.Length + utf8NameBytes.Length;
-#if NETSTANDARD2_0
+
             byte[] bytesToHash = new byte[bytesToHashCount];
-#else
-            Span<byte> bytesToHash = (utf8NameByteCount > 256) ? new byte[bytesToHashCount] : stackalloc byte[bytesToHashCount];
-#endif
-            
             namespaceBytes.CopyTo(bytesToHash);
-#if NETSTANDARD2_0
             utf8NameBytes.CopyTo(bytesToHash, namespaceBytes.Length);
-#else
-            utf8NameBytes.CopyTo(bytesToHash[namespaceBytes.Length..]);
-#endif
             HashAlgorithm hashAlgorithm = HashAlgorithm.Value;
-#if NETSTANDARD2_0
             var hash = hashAlgorithm.ComputeHash(bytesToHash);
             return CreateGuidFromBigEndianBytes(hash.AsSpan(0 , 16));
 #else
+            Span<byte> utf8NameBytes = (utf8NameByteCount > 256) ? new byte[utf8NameByteCount] : stackalloc byte[utf8NameByteCount];
+            Encoding.UTF8.GetBytes(name, utf8NameBytes);
+
+            //put the name space ID in network byte order.
+            Span<byte> namespaceBytes = stackalloc byte[16];
+            namespaceId.TryWriteBytes(namespaceBytes, bigEndian: true, out var _);
+
+            //Compute the hash of the name space ID concatenated with the name.
+            int bytesToHashCount = namespaceBytes.Length + utf8NameBytes.Length;
+
+            Span<byte> bytesToHash = (utf8NameByteCount > 256) ? new byte[bytesToHashCount] : stackalloc byte[bytesToHashCount];
+            namespaceBytes.CopyTo(bytesToHash);
+            utf8NameBytes.CopyTo(bytesToHash[namespaceBytes.Length..]);
+            HashAlgorithm hashAlgorithm = HashAlgorithm.Value;
             Span<byte> hash = stackalloc byte[hashAlgorithm.HashSize / 8];
             hashAlgorithm.TryComputeHash(bytesToHash, hash, out var _);
             return CreateGuidFromBigEndianBytes(hash[0..16]);

--- a/Src/UUIDNext/Generator/UuidNameGeneratorBase.cs
+++ b/Src/UUIDNext/Generator/UuidNameGeneratorBase.cs
@@ -13,8 +13,13 @@ namespace UUIDNext.Generator
         {
             //Convert the name to a canonical sequence of octets (as defined by the standards or conventions of its name space);
             var utf8NameByteCount = Encoding.UTF8.GetByteCount(name.Normalize(NormalizationForm.FormC));
+#if NETSTANDARD2_0
+            byte[] utf8NameBytes = new byte[utf8NameByteCount];
+            Encoding.UTF8.GetBytes(name, 0, name.Length, utf8NameBytes, 0);
+#else
             Span<byte> utf8NameBytes = (utf8NameByteCount > 256) ? new byte[utf8NameByteCount] : stackalloc byte[utf8NameByteCount];
             Encoding.UTF8.GetBytes(name, utf8NameBytes);
+#endif
 
             //put the name space ID in network byte order.
             Span<byte> namespaceBytes = stackalloc byte[16];
@@ -22,15 +27,27 @@ namespace UUIDNext.Generator
 
             //Compute the hash of the name space ID concatenated with the name.
             int bytesToHashCount = namespaceBytes.Length + utf8NameBytes.Length;
+#if NETSTANDARD2_0
+            byte[] bytesToHash = new byte[bytesToHashCount];
+#else
             Span<byte> bytesToHash = (utf8NameByteCount > 256) ? new byte[bytesToHashCount] : stackalloc byte[bytesToHashCount];
+#endif
+            
             namespaceBytes.CopyTo(bytesToHash);
+#if NETSTANDARD2_0
+            utf8NameBytes.CopyTo(bytesToHash, namespaceBytes.Length);
+#else
             utf8NameBytes.CopyTo(bytesToHash[namespaceBytes.Length..]);
-
+#endif
             HashAlgorithm hashAlgorithm = HashAlgorithm.Value;
+#if NETSTANDARD2_0
+            var hash = hashAlgorithm.ComputeHash(bytesToHash);
+            return CreateGuidFromBigEndianBytes(hash.AsSpan(0 , 16));
+#else
             Span<byte> hash = stackalloc byte[hashAlgorithm.HashSize / 8];
             hashAlgorithm.TryComputeHash(bytesToHash, hash, out var _);
-
             return CreateGuidFromBigEndianBytes(hash[0..16]);
+#endif
         }
     }
 }

--- a/Src/UUIDNext/Generator/UuidNameGeneratorBase.cs
+++ b/Src/UUIDNext/Generator/UuidNameGeneratorBase.cs
@@ -23,12 +23,13 @@ namespace UUIDNext.Generator
 
             //Compute the hash of the name space ID concatenated with the name.
             int bytesToHashCount = namespaceBytes.Length + utf8NameBytes.Length;
-
             byte[] bytesToHash = new byte[bytesToHashCount];
             namespaceBytes.CopyTo(bytesToHash);
             utf8NameBytes.CopyTo(bytesToHash, namespaceBytes.Length);
+
             HashAlgorithm hashAlgorithm = HashAlgorithm.Value;
             var hash = hashAlgorithm.ComputeHash(bytesToHash);
+
             return CreateGuidFromBigEndianBytes(hash.AsSpan(0 , 16));
 #else
             Span<byte> utf8NameBytes = (utf8NameByteCount > 256) ? new byte[utf8NameByteCount] : stackalloc byte[utf8NameByteCount];
@@ -40,13 +41,14 @@ namespace UUIDNext.Generator
 
             //Compute the hash of the name space ID concatenated with the name.
             int bytesToHashCount = namespaceBytes.Length + utf8NameBytes.Length;
-
             Span<byte> bytesToHash = (utf8NameByteCount > 256) ? new byte[bytesToHashCount] : stackalloc byte[bytesToHashCount];
             namespaceBytes.CopyTo(bytesToHash);
             utf8NameBytes.CopyTo(bytesToHash[namespaceBytes.Length..]);
+
             HashAlgorithm hashAlgorithm = HashAlgorithm.Value;
             Span<byte> hash = stackalloc byte[hashAlgorithm.HashSize / 8];
             hashAlgorithm.TryComputeHash(bytesToHash, hash, out var _);
+
             return CreateGuidFromBigEndianBytes(hash[0..16]);
 #endif
         }

--- a/Src/UUIDNext/Generator/UuidTimestampGeneratorBase.cs
+++ b/Src/UUIDNext/Generator/UuidTimestampGeneratorBase.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Buffers.Binary;
-using System.Security.Cryptography;
+using UUIDNext.Tools;
 
 namespace UUIDNext.Generator
 {
@@ -90,7 +90,7 @@ namespace UUIDNext.Generator
         {
             // following section 6.2 on "Fixed-Length Dedicated Counter Seeding", the initial value of the sequence is randomized
             Span<byte> buffer = stackalloc byte[2];
-            RandomNumberGenerator.Fill(buffer);
+            buffer.FillWithRandom();
             // Setting the highest bit to 0 mitigate the risk of a sequence overflow (see section 6.2)
             buffer[0] &= 0b0000_0111;
             return BinaryPrimitives.ReadUInt16BigEndian(buffer);

--- a/Src/UUIDNext/Generator/UuidV4Generator.cs
+++ b/Src/UUIDNext/Generator/UuidV4Generator.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Security.Cryptography;
+using UUIDNext.Tools;
 
 namespace UUIDNext.Generator
 {
@@ -13,7 +13,7 @@ namespace UUIDNext.Generator
         public Guid New()
         {
             Span<byte> bytes = stackalloc byte[16];
-            RandomNumberGenerator.Fill(bytes);
+            bytes.FillWithRandom();
             return CreateGuidFromBigEndianBytes(bytes);
         }
     }

--- a/Src/UUIDNext/Generator/UuidV7Generator.cs
+++ b/Src/UUIDNext/Generator/UuidV7Generator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Buffers.Binary;
-using System.Security.Cryptography;
 using UUIDNext.Tools;
 
 namespace UUIDNext.Generator

--- a/Src/UUIDNext/Generator/UuidV7Generator.cs
+++ b/Src/UUIDNext/Generator/UuidV7Generator.cs
@@ -32,12 +32,12 @@ namespace UUIDNext.Generator
 
             Span<byte> bytes = stackalloc byte[16];
 
-            TimeSpan unixTimeStamp = date - DateTime.UnixEpoch;
-            long timestampInMs = Convert.ToInt64(Math.Floor(unixTimeStamp.TotalMilliseconds));
+            
+            long timestampInMs = ((DateTimeOffset)date).ToUnixTimeMilliseconds();
 
-            SetSequence(bytes[6..8], ref timestampInMs);
-            SetTimestamp(bytes[0..6], timestampInMs);
-            RandomNumberGenerator.Fill(bytes[8..16]);
+            SetSequence(bytes.Slice(6,2), ref timestampInMs);
+            SetTimestamp(bytes.Slice(0, 6), timestampInMs);
+            bytes.Slice(8, 8).FillWithRandom();
 
             return CreateGuidFromBigEndianBytes(bytes);
         }
@@ -46,7 +46,7 @@ namespace UUIDNext.Generator
         {
             Span<byte> timestampInMillisecondsBytes = stackalloc byte[8];
             BinaryPrimitives.TryWriteInt64BigEndian(timestampInMillisecondsBytes, timestampInMs);
-            timestampInMillisecondsBytes[2..8].CopyTo(bytes);
+            timestampInMillisecondsBytes.Slice(2, 6).CopyTo(bytes);
         }
 
         [Obsolete("Use UuidDecoder.DecodeUuidV7 instead. This function will be removed in the next version")]

--- a/Src/UUIDNext/Generator/UuidV8SqlServerGenerator.cs
+++ b/Src/UUIDNext/Generator/UuidV8SqlServerGenerator.cs
@@ -37,12 +37,11 @@ namespace UUIDNext.Generator
 
             Span<byte> bytes = stackalloc byte[16];
 
-            TimeSpan unixTimeStamp = date - DateTime.UnixEpoch;
-            long timestampInMs = Convert.ToInt64(Math.Floor(unixTimeStamp.TotalMilliseconds));
+            long timestampInMs = ((DateTimeOffset)date).ToUnixTimeMilliseconds();
 
-            SetSequence(bytes[8..10], ref timestampInMs);
-            SetTimestamp(bytes[10..16], timestampInMs);
-            RandomNumberGenerator.Fill(bytes[0..8]);
+            SetSequence(bytes.Slice(8,2), ref timestampInMs);
+            SetTimestamp(bytes.Slice(10, 6), timestampInMs);
+            bytes.Slice(0, 8).FillWithRandom();
 
             return CreateGuidFromBigEndianBytes(bytes);
         }
@@ -51,7 +50,7 @@ namespace UUIDNext.Generator
         {
             Span<byte> timestampInMillisecondsBytes = stackalloc byte[8];
             BinaryPrimitives.TryWriteInt64BigEndian(timestampInMillisecondsBytes, timestampInMs);
-            timestampInMillisecondsBytes[2..8].CopyTo(bytes);
+            timestampInMillisecondsBytes.Slice(2, 6).CopyTo(bytes);
         }
 
         [Obsolete("Use UuidDecoder.DecodeUuidV8ForSqlServer instead. This function will be removed in the next version")]

--- a/Src/UUIDNext/GuidHelper.cs
+++ b/Src/UUIDNext/GuidHelper.cs
@@ -7,7 +7,7 @@ namespace UUIDNext
         public static Guid FromBytes(Span<byte> bytes, bool bigEndian)
         {
             if (!bigEndian)
-#if NETSTANDARD2_0
+#if NET472_OR_GREATER
                 return new(bytes.ToArray());
 #else
                 return new(bytes);
@@ -17,7 +17,7 @@ namespace UUIDNext
             
             bytes.CopyTo(localBytes);
             SwitchByteOrder(localBytes);
-#if NETSTANDARD2_0
+#if NET472_OR_GREATER
             return new(localBytes.ToArray());
 #else
             return new(localBytes);
@@ -36,7 +36,7 @@ namespace UUIDNext
 
         public static bool TryWriteBytes(this Guid guid, Span<byte> bytes, bool bigEndian, out int bytesWritten)
         {
-#if NETSTANDARD2_0
+#if NET472_OR_GREATER
             if (bytes.Length < 16)
             {
                 bytesWritten = 0;

--- a/Src/UUIDNext/Tools/RandomNumberGeneratorPolyfill.cs
+++ b/Src/UUIDNext/Tools/RandomNumberGeneratorPolyfill.cs
@@ -9,7 +9,7 @@ namespace UUIDNext.Tools
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void FillWithRandom(this Span<byte> span)
         {
-#if NETSTANDARD2_0
+#if NET472_OR_GREATER
             using var rng = RandomNumberGenerator.Create();
             var tempBytes = new byte[span.Length];
             rng.GetBytes(tempBytes);

--- a/Src/UUIDNext/Tools/RandomNumberGeneratorPolyfill.cs
+++ b/Src/UUIDNext/Tools/RandomNumberGeneratorPolyfill.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace UUIDNext.Tools
+{
+    public static class RandomNumberGeneratorPolyfill
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void FillWithRandom(this Span<byte> span)
+        {
+#if NETSTANDARD2_0
+            using var rng = RandomNumberGenerator.Create();
+            var tempBytes = new byte[span.Length];
+            rng.GetBytes(tempBytes);
+            tempBytes.CopyTo(span);
+#else
+            RandomNumberGenerator.Fill(span);
+#endif
+        }
+    }
+}

--- a/Src/UUIDNext/Tools/UuidDecoder.cs
+++ b/Src/UUIDNext/Tools/UuidDecoder.cs
@@ -11,10 +11,10 @@ namespace UUIDNext.Tools
             guid.TryWriteBytes(bytes, bigEndian: true, out var _);
 
             Span<byte> timestampBytes = stackalloc byte[8];
-            bytes[0..6].CopyTo(timestampBytes[2..8]);
+            bytes.Slice(0, 6).CopyTo(timestampBytes.Slice(2, 6));
             long timestampMs = BinaryPrimitives.ReadInt64BigEndian(timestampBytes);
 
-            var sequenceBytes = bytes[6..8];
+            var sequenceBytes = bytes.Slice(6, 2);
             //remove version information
             sequenceBytes[0] &= 0b0000_1111;
             short sequence = BinaryPrimitives.ReadInt16BigEndian(sequenceBytes);
@@ -28,10 +28,10 @@ namespace UUIDNext.Tools
             guid.TryWriteBytes(bytes, bigEndian: true, out var _);
 
             Span<byte> timestampBytes = stackalloc byte[8];
-            bytes[10..16].CopyTo(timestampBytes[2..8]);
+            bytes.Slice(10, 6).CopyTo(timestampBytes.Slice(2, 6));
             long timestampMs = BinaryPrimitives.ReadInt64BigEndian(timestampBytes);
 
-            var sequenceBytes = bytes[8..10];
+            var sequenceBytes = bytes.Slice(8, 2);
             //remove variant information
             sequenceBytes[0] &= 0b0011_1111;
             short sequence = BinaryPrimitives.ReadInt16BigEndian(sequenceBytes);

--- a/Src/UUIDNext/UUIDNext.csproj
+++ b/Src/UUIDNext/UUIDNext.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
 		<LangVersion>9</LangVersion>
 		<Version>3.0.0-beta2</Version>
 		<Authors>Matthieu Mourisson</Authors>
@@ -22,6 +22,10 @@
 		<PackageReleaseNotes>See https://github.com/mareek/UUIDNext/blob/main/Changelog.md</PackageReleaseNotes>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<DefineConstants>TRACE;SUPPORTS_RANGE;</DefineConstants>
+	</PropertyGroup>
+	
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 		<None Include="..\..\Images\Logo_128.png" Pack="true" PackagePath="\"/>
@@ -33,6 +37,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.5.5"/>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
 	</ItemGroup>
 

--- a/Src/UUIDNext/UUIDNext.csproj
+++ b/Src/UUIDNext/UUIDNext.csproj
@@ -1,47 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-		<LangVersion>9</LangVersion>
-		<Version>3.0.0-beta2</Version>
-		<Authors>Matthieu Mourisson</Authors>
-		<PackageId>UUIDNext</PackageId>
-		<PackageLicenseExpression>0BSD</PackageLicenseExpression>
-		<PackageTags>UUID;GUID;UUIDv5;UUIDv7;UUIDv8;</PackageTags>
-		<PackageProjectUrl>https://github.com/mareek/UUIDNext</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/mareek/UUIDNext</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<Description>A fast and modern .NET library to generate UUID/GUID that are either sequential and database friendly (versions 7), name based (versions  5) or random (version 4).</Description>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageIcon>Logo_128.png</PackageIcon>
-		<PackageReleaseNotes>See https://github.com/mareek/UUIDNext/blob/main/Changelog.md</PackageReleaseNotes>
-	</PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.1;net472;net48</TargetFrameworks>
+        <LangVersion>9</LangVersion>
+        <Version>3.0.0-beta2</Version>
+        <Authors>Matthieu Mourisson</Authors>
+        <PackageId>UUIDNext</PackageId>
+        <PackageLicenseExpression>0BSD</PackageLicenseExpression>
+        <PackageTags>UUID;GUID;UUIDv5;UUIDv7;UUIDv8;</PackageTags>
+        <PackageProjectUrl>https://github.com/mareek/UUIDNext</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/mareek/UUIDNext</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <Description>A fast and modern .NET library to generate UUID/GUID that are either sequential and database friendly (versions 7), name based (versions 5) or random (version 4).</Description>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>Logo_128.png</PackageIcon>
+        <PackageReleaseNotes>See https://github.com/mareek/UUIDNext/blob/main/Changelog.md</PackageReleaseNotes>
+    </PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<DefineConstants>TRACE;SUPPORTS_RANGE;</DefineConstants>
-	</PropertyGroup>
-	
-	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-		<None Include="..\..\Images\Logo_128.png" Pack="true" PackagePath="\"/>
-	</ItemGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <DefineConstants>TRACE;SUPPORTS_RANGE;</DefineConstants>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<InternalsVisibleTo Include="UUIDNext.Test" />
-		<InternalsVisibleTo Include="UUIDNext.Benchmarks" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\Images\Logo_128.png" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.5.5"/>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-	</ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="UUIDNext.Test"/>
+        <InternalsVisibleTo Include="UUIDNext.Benchmarks"/>
+    </ItemGroup>
 
-	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-	</PropertyGroup>
+    <ItemGroup>
+        <PackageReference Condition="('$(TargetFramework)' == 'net472') OR ('$(TargetFramework)' == 'net48')"
+                          Include="System.Memory" Version="4.5.5"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adding .NETStandard v2 support so that this can be used with .NET framework too.

Please have a look. I am not sure how you would prefer to have the cross standard code to be laid out. for now used preprocessor instructions `#if NETSTANDARD2_0` and likes but happy to take a different approach.

Tested on .NET4.7.2