### PR TITLE
Eliminate extra buffer usage for timestamp in UUIDv7 generation

### DIFF
--- a/Src/UUIDNext/Generator/UuidV7Generator.cs
+++ b/Src/UUIDNext/Generator/UuidV7Generator.cs
@@ -34,12 +34,12 @@ namespace UUIDNext.Generator
             Span<byte> buffer = stackalloc byte[18];
 
             // Offset to the bytes that are used in UUIDv7.
-            var bytes = buffer[2..];
+            var bytes = buffer.Slice(2);
 
             long timestampInMs = ((DateTimeOffset)date).ToUnixTimeMilliseconds();
 
             SetSequence(bytes.Slice(6,2), ref timestampInMs);
-            SetTimestamp(buffer[..8], timestampInMs);
+            SetTimestamp(buffer.Slice(0, 8), timestampInMs);
             RandomNumberGeneratorPolyfill.Fill(bytes.Slice(8, 8));
 
             return CreateGuidFromBigEndianBytes(bytes);


### PR DESCRIPTION
UUIDv7 generation utilizes an additional 8-bytes buffer for setting timestamp. This PR removes the need for additional buffer.

**Changes:**
- Increase original buffer size from 16 to 18 bytes.
- Remove usage of temporary buffer for setting timestamp.
- Avoid redundant copy of timestamp data by writing it directly to the original buffer.