### PR TITLE
Work with normalized strings

### DIFF
--- a/Src/UUIDNext.Test/Generator/UuidV5GeneratorTest.cs
+++ b/Src/UUIDNext.Test/Generator/UuidV5GeneratorTest.cs
@@ -35,5 +35,16 @@ namespace UUIDNext.Test.Generator
             UuidTestHelper.CheckVersionAndVariant(generator.New(namespaceId1, UuidTestHelper.LoremIpsum), 5);
             UuidTestHelper.CheckVersionAndVariant(generator.New(namespaceId2, poetry), 5);
         }
+
+        [Fact]
+        public void UuidV5MustHandleNotNormalizedString()
+        {
+            Guid namespaceId = Guid.NewGuid();
+
+            const string poetry = "й";
+            UuidV5Generator generator = new();
+            var uuidv5 = generator.New(namespaceId, poetry);
+            UuidTestHelper.CheckVersionAndVariant(generator.New(namespaceId, poetry), 5);
+        }
     }
 }

--- a/Src/UUIDNext/Tools/UuidToolkit.cs
+++ b/Src/UUIDNext/Tools/UuidToolkit.cs
@@ -82,10 +82,11 @@ public static class UuidToolkit
     internal static Guid CreateUuidFromName(Guid namespaceId, string name, HashAlgorithm hashAlgorithm, byte version)
     {
         //Convert the name to a canonical sequence of octets (as defined by the standards or conventions of its name space);
-        var utf8NameByteCount = Encoding.UTF8.GetByteCount(name.Normalize(NormalizationForm.FormC));
+        var normalizedName = name.Normalize(NormalizationForm.FormC);
+        var utf8NameByteCount = Encoding.UTF8.GetByteCount(normalizedName);
 #if NETSTANDARD2_0
         byte[] utf8NameBytes = new byte[utf8NameByteCount];
-        Encoding.UTF8.GetBytes(name, 0, name.Length, utf8NameBytes, 0);
+        Encoding.UTF8.GetBytes(normalizedName, 0, normalizedName.Length, utf8NameBytes, 0);
 
         //put the name space ID in network byte order.
         Span<byte> namespaceBytes = stackalloc byte[16];
@@ -102,7 +103,7 @@ public static class UuidToolkit
         return CreateGuidFromBigEndianBytes(hash.AsSpan(0, 16), version);
 #else
         Span<byte> utf8NameBytes = (utf8NameByteCount > 256) ? new byte[utf8NameByteCount] : stackalloc byte[utf8NameByteCount];
-        Encoding.UTF8.GetBytes(name, utf8NameBytes);
+        Encoding.UTF8.GetBytes(normalizedName, utf8NameBytes);
 
         //put the name space ID in network byte order.
         Span<byte> namespaceBytes = stackalloc byte[16];


### PR DESCRIPTION
I found an error when processing an unnormalized string, in particular `й`.

This character takes up 4 bytes, while after normalization it takes up 2. Due to the fact that the number of bytes decreases during normalization, an error occurs when moving bytes.
